### PR TITLE
#49 Added mime type to HC share button

### DIFF
--- a/hyperion-crash/src/main/java/com/willowtreeapps/hyperion/crash/CrashActivity.java
+++ b/hyperion-crash/src/main/java/com/willowtreeapps/hyperion/crash/CrashActivity.java
@@ -45,6 +45,7 @@ public class CrashActivity extends AppCompatActivity implements View.OnClickList
                 final Intent intent = new Intent(Intent.ACTION_SEND);
                 final String text = getExternalText();
                 intent.putExtra(Intent.EXTRA_TEXT, text);
+                intent.setType("text/plain");
                 startActivity(Intent.createChooser(intent, "Share"));
             }
         });


### PR DESCRIPTION
Fixes #49
Mime type set to `text/plain` per Android guide
https://developer.android.com/training/sharing/send.html#send-text-content