### PR TITLE
Center measurement views on line

### DIFF
--- a/hyperion-measurement/src/main/java/com/willowtreeapps/hyperion/measurement/MeasurementOverlayView.java
+++ b/hyperion-measurement/src/main/java/com/willowtreeapps/hyperion/measurement/MeasurementOverlayView.java
@@ -87,7 +87,7 @@ class MeasurementOverlayView extends FrameLayout {
         canvas.drawRect(rectPrimary, paintPrimary);
 
         /*
-         * Start guidelines
+         * guidelines
          */
         // top-left to top
         path.reset();
@@ -136,9 +136,6 @@ class MeasurementOverlayView extends FrameLayout {
         path.moveTo(rectPrimary.right, rectPrimary.top);
         path.lineTo(getRight(), rectPrimary.top);
         canvas.drawPath(path, paintDashed);
-        /*
-         * End guidelines
-         */
 
         if (rectSecondary == null) {
             // draw width measurement text
@@ -161,12 +158,15 @@ class MeasurementOverlayView extends FrameLayout {
         } else {
             canvas.drawRect(rectSecondary, paintSecondary);
 
+            /*
+             * view to view measurement views
+             */
             if (rectPrimary.bottom < rectSecondary.top) {
                 // secondary is below. draw vertical line.
                 canvas.drawLine(rectSecondary.centerX(), rectPrimary.bottom, rectSecondary.centerX(), rectSecondary.top, paintPrimary);
                 if (measurementHeightText != null) {
                     canvas.save();
-                    canvas.translate(rectSecondary.centerX() + measurementTextOffset,
+                    canvas.translate(rectSecondary.centerX() - measurementHeightText.getWidth() / 2,
                             (rectPrimary.bottom + rectSecondary.top) / 2 - (measurementHeightText.getHeight() / 2));
                     measurementHeightText.draw(canvas);
                     canvas.restore();
@@ -188,7 +188,7 @@ class MeasurementOverlayView extends FrameLayout {
                 canvas.drawLine(rectSecondary.centerX(), rectPrimary.top, rectSecondary.centerX(), rectSecondary.bottom, paintPrimary);
                 if (measurementHeightText != null) {
                     canvas.save();
-                    canvas.translate(rectSecondary.centerX() + measurementTextOffset,
+                    canvas.translate(rectSecondary.centerX() - measurementHeightText.getWidth() / 2,
                             (rectPrimary.top + rectSecondary.bottom) / 2 - (measurementHeightText.getHeight() / 2));
                     measurementHeightText.draw(canvas);
                     canvas.restore();
@@ -218,7 +218,7 @@ class MeasurementOverlayView extends FrameLayout {
             }
 
             /*
-             * Start measurement views
+             * parent to child measurement views
              */
             if (inside != null && outside != null) {
                 // left inside
@@ -261,9 +261,6 @@ class MeasurementOverlayView extends FrameLayout {
                     canvas.restore();
                 }
             }
-            /*
-             * End measurement views
-             */
         }
     }
 

--- a/hyperion-measurement/src/main/java/com/willowtreeapps/hyperion/measurement/MeasurementOverlayView.java
+++ b/hyperion-measurement/src/main/java/com/willowtreeapps/hyperion/measurement/MeasurementOverlayView.java
@@ -178,7 +178,7 @@ class MeasurementOverlayView extends FrameLayout {
                 if (measurementWidthText != null) {
                     canvas.save();
                     canvas.translate((rectPrimary.right + rectSecondary.left) / 2 - (measurementWidthText.getWidth() / 2),
-                            rectSecondary.centerY() - measurementTextOffset - measurementWidthText.getHeight());
+                            rectSecondary.centerY() - measurementWidthText.getHeight() / 2);
                     measurementWidthText.draw(canvas);
                     canvas.restore();
                 }
@@ -200,7 +200,7 @@ class MeasurementOverlayView extends FrameLayout {
                 if (measurementWidthText != null) {
                     canvas.save();
                     canvas.translate((rectPrimary.left + rectSecondary.right) / 2 - (measurementWidthText.getWidth() / 2),
-                            rectSecondary.centerY() - measurementTextOffset);
+                            rectSecondary.centerY() - measurementWidthText.getHeight() / 2);
                     measurementWidthText.draw(canvas);
                     canvas.restore();
                 }


### PR DESCRIPTION
The view to view measurement views were off center. This centers them on the guideline

Before:
![screenshot_20180403-010841](https://user-images.githubusercontent.com/9043915/38282239-194c76d0-377d-11e8-8881-3b05a61948cd.png)
(vertical has already been fixed for next 2)
![screenshot_20180403-201850](https://user-images.githubusercontent.com/9043915/38282241-1aa8bf7a-377d-11e8-9671-a96874344265.png)
![screenshot_20180403-201856](https://user-images.githubusercontent.com/9043915/38282242-1c2949b4-377d-11e8-9d70-b3223b9997e5.png)


After: 
![screenshot_20180403-200121](https://user-images.githubusercontent.com/9043915/38282245-1f64fb96-377d-11e8-986d-2ead760ec644.png)
![screenshot_20180403-200400](https://user-images.githubusercontent.com/9043915/38282247-2099ee0e-377d-11e8-85c1-776885053e9c.png)
![screenshot_20180403-201657](https://user-images.githubusercontent.com/9043915/38282248-21a5a37e-377d-11e8-916c-b2cfea604595.png)
![screenshot_20180403-201757](https://user-images.githubusercontent.com/9043915/38282249-22a4a69e-377d-11e8-8387-21af0257ca98.png)
