### PR TITLE
Allow host app to add plugin manually

### DIFF
--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/Hyperion.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/Hyperion.java
@@ -53,6 +53,14 @@ public final class Hyperion {
         AppComponent.Holder.getInstance().getPublicControl().setPluginSource(pluginSource);
     }
 
+    /**
+     * Get a plugin source.
+     * Clients can wrap and delegate the {@link PluginSource}.
+     */
+    public static PluginSource getPluginSource() {
+        return AppComponent.Holder.getInstance().getPublicControl().getPluginSource();
+    }
+
     private Hyperion() {
         throw new AssertionError("No instances.");
     }

--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/PublicControl.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/PublicControl.java
@@ -13,4 +13,6 @@ public interface PublicControl {
     float getShakeGestureSensitivity();
 
     void setPluginSource(PluginSource pluginSource);
+
+    PluginSource getPluginSource();
 }

--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/PublicControlImpl.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/PublicControlImpl.java
@@ -59,4 +59,9 @@ class PublicControlImpl implements PublicControl {
     public void setPluginSource(PluginSource pluginSource) {
         container.setPluginSource(pluginSource);
     }
+
+    @Override
+    public PluginSource getPluginSource() {
+        return container.getPluginSource();
+    }
 }


### PR DESCRIPTION
This is useful when you want to add an application-specific plugin in host app