### PR TITLE
#73 Alphabetically sort modules in the hyperion list

### DIFF
--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionPluginView.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionPluginView.java
@@ -20,7 +20,9 @@ import com.willowtreeapps.hyperion.plugin.v1.HyperionMenu;
 import com.willowtreeapps.hyperion.plugin.v1.MenuState;
 import com.willowtreeapps.hyperion.plugin.v1.PluginModule;
 
+import java.util.Comparator;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.inject.Inject;
 
@@ -98,7 +100,10 @@ public class HyperionPluginView extends FrameLayout {
     private void populatePluginList(Try<Plugins> result) {
         try {
             final Plugins plugins = result.get();
-            modules = plugins.createModules();
+            final Comparator<PluginModule> comparator = new AlphabeticalComparator(getContext());
+            final Set<PluginModule> sortedModules = new TreeSet<>(comparator);
+            sortedModules.addAll(plugins.createModules());
+            this.modules = sortedModules;
         } catch (Throwable t) {
             // TODO
             t.printStackTrace();
@@ -124,5 +129,27 @@ public class HyperionPluginView extends FrameLayout {
             }
         }
         pluginExtension.setHyperionMenu(null);
+    }
+
+    private static final class AlphabeticalComparator implements Comparator<PluginModule> {
+
+        private final Context context;
+
+        private AlphabeticalComparator(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public int compare(PluginModule left, PluginModule right) {
+            String leftName = getName(left);
+            String rightName = getName(right);
+            return leftName.compareTo(rightName);
+        }
+
+        private String getName(PluginModule pluginModule) {
+            int resName = pluginModule.getName();
+            if (resName == R.string.hype_module_name) return pluginModule.getClass().getSimpleName();
+            else return context.getString(resName);
+        }
     }
 }

--- a/hyperion-plugin/src/main/java/com/willowtreeapps/hyperion/plugin/v1/PluginModule.java
+++ b/hyperion-plugin/src/main/java/com/willowtreeapps/hyperion/plugin/v1/PluginModule.java
@@ -3,9 +3,12 @@ package com.willowtreeapps.hyperion.plugin.v1;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
+import com.willowtreeapps.hyperion.plugin.R;
 
 public abstract class PluginModule {
 
@@ -16,6 +19,16 @@ public abstract class PluginModule {
         this.extension = extension;
         this.context = context;
         onCreate();
+    }
+
+    /**
+     * The name of the plugin module. This should be the same name as displayed by the returned plugin view.
+     *
+     * @return the name of the plugin module
+     */
+    @StringRes
+    public int getName() {
+        return R.string.hype_module_name;
     }
 
     protected void onCreate() {

--- a/hyperion-plugin/src/main/res/values/strings.xml
+++ b/hyperion-plugin/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+<string name="hype_module_name">Hyperion Plugin</string>
+</resources>


### PR DESCRIPTION
Resolves #73 
This is probably 'good enough' but I'm open to input on how to make this better. I would prefer plugins define their names explicitly, however, I think I created a good enough fallback as it seems most plugin classes are well named.