### PR TITLE
Plugin menu item subtitles

### DIFF
--- a/hyperion-attr/src/main/res/layout/ha_item_plugin.xml
+++ b/hyperion-attr/src/main/res/layout/ha_item_plugin.xml
@@ -18,12 +18,28 @@
         app:tint="@color/hype_plugin_color_selector"
         android:duplicateParentState="true"/>
 
-    <TextView
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:textColor="@color/hype_plugin_color_selector"
-        android:text="@string/ha_plugin_name"
-        android:duplicateParentState="true"/>
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:textColor="@color/hype_plugin_color_selector"
+            android:text="@string/ha_plugin_name"
+            android:duplicateParentState="true"
+            android:textSize="16sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:textColor="@color/hype_plugin_color_selector"
+            android:text="@string/ha_plugin_subtitle"
+            android:duplicateParentState="true"/>
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/hyperion-attr/src/main/res/values/strings.xml
+++ b/hyperion-attr/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <public name="ha_attributes" type="string">Hyperion-Attributes</public>
     <string name="ha_plugin_name">Attributes Inspector</string>
+    <string name="ha_plugin_subtitle">Tap to inspect views and adjust their attributes.</string>
     <string name="ha_cd_visual">Visual Value</string>
     <string name="ha_enter_value">Enter value</string>
     <string name="ha_mutate">Mutate</string>

--- a/hyperion-disk/src/main/res/layout/hd_item_plugin.xml
+++ b/hyperion-disk/src/main/res/layout/hd_item_plugin.xml
@@ -19,12 +19,29 @@
         app:tint="@color/hype_plugin_color_selector"
         android:duplicateParentState="true"/>
 
-    <TextView
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:textColor="@color/hype_plugin_color_selector"
-        android:text="@string/hd_plugin_name"
-        android:duplicateParentState="true"/>
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:textColor="@color/hype_plugin_color_selector"
+            android:text="@string/hd_plugin_name"
+            android:duplicateParentState="true"
+            android:textSize="16sp"
+            />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:textColor="@color/hype_plugin_color_selector"
+            android:text="@string/hd_plugin_subtitle"
+            android:duplicateParentState="true"/>
+    </LinearLayout>
+
 
 </LinearLayout>

--- a/hyperion-disk/src/main/res/values/strings.xml
+++ b/hyperion-disk/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <public name="hd_disk" type="string">Hyperion-Disk</public>
     <string name="hd_plugin_name">File Explorer</string>
+    <string name="hd_plugin_subtitle">Browse, delete, or share your app\'s files.</string>
     <string name="hd_up">..</string>
     <string name="hd_share">Share</string>
     <string name="hd_delete">Delete</string>

--- a/hyperion-geiger-counter/src/main/res/layout/hgc_item_plugin.xml
+++ b/hyperion-geiger-counter/src/main/res/layout/hgc_item_plugin.xml
@@ -18,12 +18,28 @@
         app:tint="@color/hype_plugin_color_selector"
         android:duplicateParentState="true"/>
 
-    <TextView
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:textColor="@color/hype_plugin_color_selector"
-        android:text="@string/hgc_plugin_name"
-        android:duplicateParentState="true"/>
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:duplicateParentState="true"
+            android:text="@string/hgc_plugin_name"
+            android:textColor="@color/hype_plugin_color_selector"
+            android:textSize="16sp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:duplicateParentState="true"
+            android:text="@string/hgc_plugin_subtitle"
+            android:textColor="@color/hype_plugin_color_selector" />
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/hyperion-geiger-counter/src/main/res/values/strings.xml
+++ b/hyperion-geiger-counter/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <public name="hgc_geiger_counter" type="string">Hyperion-Geiger-Counter</public>
     <string name="hgc_plugin_name">Geiger Counter</string>
+    <string name="hgc_plugin_subtitle">Check animation performance by listening for dropped frames.</string>
     <string name="hgc_volume_warning">Please turn up the sound volume.</string>
 </resources>

--- a/hyperion-measurement/src/main/res/layout/hm_item_plugin.xml
+++ b/hyperion-measurement/src/main/res/layout/hm_item_plugin.xml
@@ -17,13 +17,28 @@
         android:src="@drawable/hm_icon"
         app:tint="@color/hype_plugin_color_selector"
         android:duplicateParentState="true"/>
-
-    <TextView
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:textColor="@color/hype_plugin_color_selector"
-        android:text="@string/hm_plugin_name"
-        android:duplicateParentState="true"/>
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:textColor="@color/hype_plugin_color_selector"
+            android:text="@string/hm_plugin_name"
+            android:duplicateParentState="true"
+            android:textSize="16sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:textColor="@color/hype_plugin_color_selector"
+            android:text="@string/hm_plugin_subtitle"
+            android:duplicateParentState="true"/>
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/hyperion-measurement/src/main/res/values/strings.xml
+++ b/hyperion-measurement/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <public name="hm_measurements" type="string">Hyperion-Measurements</public>
     <string name="hm_plugin_name">Measurement Inspector</string>
+    <string name="hm_plugin_subtitle">Tap views to measure the distances between them.</string>
 </resources>

--- a/hyperion-phoenix/src/main/res/layout/hp_item_plugin.xml
+++ b/hyperion-phoenix/src/main/res/layout/hp_item_plugin.xml
@@ -13,6 +13,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
+        android:gravity="center_vertical"
         android:orientation="horizontal"
         tools:ignore="UseCompoundDrawables">
 

--- a/hyperion-phoenix/src/main/res/layout/hp_item_plugin.xml
+++ b/hyperion-phoenix/src/main/res/layout/hp_item_plugin.xml
@@ -24,12 +24,27 @@
             android:src="@drawable/hp_icon"
             app:tint="@color/hype_plugin_color_selector"/>
 
-        <TextView
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:textColor="@color/hype_plugin_color_selector"
-            android:text="@string/hp_plugin_name"/>
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:textColor="@color/hype_plugin_color_selector"
+                android:text="@string/hp_plugin_name"
+                android:textSize="16sp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:textColor="@color/hype_plugin_color_selector"
+                android:text="@string/hp_plugin_subtitle"/>
+
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/hyperion-phoenix/src/main/res/values/strings.xml
+++ b/hyperion-phoenix/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <public name="hp_phoenix" type="string">Hyperion-Phoenix</public>
     <string name="hp_plugin_name">Phoenix</string>
+    <string name="hp_plugin_subtitle">Clear local storage and relaunch the app.</string>
     <string name="hp_clear_cache">Clear Cache</string>
     <string name="hp_clear_data">Clear Data</string>
     <string name="hp_restart_self">Restart Self</string>

--- a/hyperion-recorder/src/main/res/layout/hr_item_plugin.xml
+++ b/hyperion-recorder/src/main/res/layout/hr_item_plugin.xml
@@ -1,38 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="131dp"
-    android:padding="@dimen/hype_plugin_padding"
-    android:orientation="horizontal"
+    android:background="?attr/selectableItemBackground"
     android:gravity="center_vertical"
-    android:background="?attr/selectableItemBackground">
+    android:minHeight="131dp"
+    android:orientation="horizontal"
+    android:padding="@dimen/hype_plugin_padding">
 
     <android.support.v7.widget.AppCompatImageView
         android:layout_width="@dimen/hype_plugin_icon_size"
         android:layout_height="@dimen/hype_plugin_icon_size"
-        android:layout_marginRight="28dp"
         android:layout_marginEnd="28dp"
+        android:layout_marginRight="28dp"
+        android:duplicateParentState="true"
         android:src="@drawable/hr_icon"
-        app:tint="@color/hype_plugin_color_selector"
-        android:duplicateParentState="true"/>
+        app:tint="@color/hype_plugin_color_selector" />
 
-    <TextView
-        android:layout_width="0dp"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:layout_gravity="center_vertical"
-        android:textColor="@color/hype_plugin_color_selector"
-        android:text="@string/hr_plugin_name"
-        android:duplicateParentState="true"/>
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:duplicateParentState="true"
+            android:text="@string/hr_plugin_name"
+            android:textColor="@color/hype_plugin_color_selector"
+            android:textSize="16sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:duplicateParentState="true"
+            android:text="@string/hr_plugin_subtitle"
+            android:textColor="@color/hype_plugin_color_selector" />
+
+    </LinearLayout>
 
     <Button
         android:id="@+id/recordings_button"
+        style="@style/Widget.AppCompat.Button.Colored"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        style="@style/Widget.AppCompat.Button.Colored"
-        android:text="@string/hr_recordings"/>
+        android:text="@string/hr_recordings" />
 
 </LinearLayout>

--- a/hyperion-recorder/src/main/res/values/strings.xml
+++ b/hyperion-recorder/src/main/res/values/strings.xml
@@ -4,5 +4,6 @@
     <string name="hr_record">Record</string>
     <string name="hr_recording">Recording</string>
     <string name="hr_plugin_name">Recorder</string>
+    <string name="hr_plugin_subtitle">Record, save, and share a video of your app.</string>
     <string name="hr_recordings">Recordings</string>
 </resources>

--- a/hyperion-recorder/src/main/res/values/strings.xml
+++ b/hyperion-recorder/src/main/res/values/strings.xml
@@ -5,5 +5,5 @@
     <string name="hr_recording">Recording</string>
     <string name="hr_plugin_name">Recorder</string>
     <string name="hr_plugin_subtitle">Record, save, and share a video of your app.</string>
-    <string name="hr_recordings">Recordings</string>
+    <string name="hr_recordings">Videos</string>
 </resources>

--- a/hyperion-shared-preferences/src/main/res/layout/hsp_item_plugin.xml
+++ b/hyperion-shared-preferences/src/main/res/layout/hsp_item_plugin.xml
@@ -19,12 +19,28 @@
         app:tint="@color/hype_plugin_color_selector"
         android:duplicateParentState="true"/>
 
-    <TextView
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:textColor="@color/hype_plugin_color_selector"
-        android:text="@string/hsp_plugin_name"
-        android:duplicateParentState="true"/>
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:textColor="@color/hype_plugin_color_selector"
+            android:text="@string/hsp_plugin_name"
+            android:duplicateParentState="true"
+            android:textSize="16sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:textColor="@color/hype_plugin_color_selector"
+            android:text="@string/hsp_plugin_subtitle"
+            android:duplicateParentState="true"/>
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/hyperion-shared-preferences/src/main/res/values/strings.xml
+++ b/hyperion-shared-preferences/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <public name="hsp_shared_preferences" type="string">Hyperion-Shared-Preferences</public>
     <string name="hsp_plugin_name">Shared Preferences</string>
+    <string name="hsp_plugin_subtitle">View and edit your app\'s key-value storage.</string>
     <string name="hsp_preference_edit_text">Preference Value</string>
     <string name="hsp_preference_edit_action_apply">Apply</string>
 </resources>


### PR DESCRIPTION
Here's a try at #78.

- Add subtitles to plugin menu items in order to explain their function with no other introduction
- Rename the Recorder plugin's "Recordings" button to "Videos" in order to afford more horizontal space to the title and subtitle

![screenshot_1523426894](https://user-images.githubusercontent.com/602569/38599153-3fe82446-3d2d-11e8-838c-ff01cac3b724.png)