### PR TITLE
Add support for sending custom data to the log buffer

### DIFF
--- a/hyperion-sample/src/main/java/com/willowtreeapps/hyperion/sample/MainActivity.java
+++ b/hyperion-sample/src/main/java/com/willowtreeapps/hyperion/sample/MainActivity.java
@@ -4,6 +4,12 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
+import com.willowtreeapps.hyperion.timber.TimberPlugin;
+import com.willowtreeapps.hyperion.timber.model.Level;
+import com.willowtreeapps.hyperion.timber.model.LogItem;
+
+import java.util.Date;
+
 import timber.log.Timber;
 
 public class MainActivity extends AppCompatActivity {
@@ -19,6 +25,9 @@ public class MainActivity extends AppCompatActivity {
         Timber.i("Hello Timber Info!");
         Timber.v("Hello Timber Verbose!");
         Timber.w("Hello Timber Warn!");
+
+        TimberPlugin.logItemBuffer
+                .enqueue(new LogItem(Level.DEBUG, new Date(), "I'm a custom message!"));
 
         if (savedInstanceState == null) {
             getSupportFragmentManager().beginTransaction()

--- a/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/TimberPlugin.java
+++ b/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/TimberPlugin.java
@@ -16,12 +16,18 @@ import timber.log.Timber;
 @AutoService(Plugin.class)
 public class TimberPlugin extends Plugin {
 
+    /**
+     * Item buffer for injecting custom logging for projects not using Timber or for non log
+     * records.
+     */
+    public static CircularBuffer<LogItem> logItemBuffer;
+
     @Override
     protected void onApplicationCreated(@NonNull Context context) {
         super.onApplicationCreated(context);
         int count = context.getResources().getInteger(R.integer.tmb_log_buffer);
-        CircularBuffer<LogItem> circularBuffer = new CircularBuffer<>(count);
-        Timber.plant(new TimberLogTree(circularBuffer));
+        logItemBuffer = new CircularBuffer<>(count);
+        Timber.plant(new TimberLogTree(logItemBuffer));
         Timber.i("TimberLogTree planted.");
     }
 


### PR DESCRIPTION
Resolves #94 
Provides a hook to inject custom log messages into the Timber Log plugin.