### PR TITLE
Fixed release build by removing hyperion-timber release dependency

### DIFF
--- a/hyperion-sample/src/debug/java/com/willowtreeapps/hyperion/sample/debug/CustomLog.java
+++ b/hyperion-sample/src/debug/java/com/willowtreeapps/hyperion/sample/debug/CustomLog.java
@@ -1,0 +1,19 @@
+package com.willowtreeapps.hyperion.sample.debug;
+
+import com.willowtreeapps.hyperion.timber.TimberPlugin;
+import com.willowtreeapps.hyperion.timber.model.Level;
+import com.willowtreeapps.hyperion.timber.model.LogItem;
+
+import java.util.Date;
+
+public class CustomLog {
+
+    private CustomLog() {
+    }
+
+    public static void debug(String message) {
+        TimberPlugin.logItemBuffer
+                .enqueue(new LogItem(Level.DEBUG, new Date(), message));
+    }
+
+}

--- a/hyperion-sample/src/main/java/com/willowtreeapps/hyperion/sample/MainActivity.java
+++ b/hyperion-sample/src/main/java/com/willowtreeapps/hyperion/sample/MainActivity.java
@@ -4,11 +4,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
-import com.willowtreeapps.hyperion.timber.TimberPlugin;
-import com.willowtreeapps.hyperion.timber.model.Level;
-import com.willowtreeapps.hyperion.timber.model.LogItem;
-
-import java.util.Date;
+import com.willowtreeapps.hyperion.sample.debug.CustomLog;
 
 import timber.log.Timber;
 
@@ -26,8 +22,7 @@ public class MainActivity extends AppCompatActivity {
         Timber.v("Hello Timber Verbose!");
         Timber.w("Hello Timber Warn!");
 
-        TimberPlugin.logItemBuffer
-                .enqueue(new LogItem(Level.DEBUG, new Date(), "I'm a custom message!"));
+        CustomLog.debug("I'm a custom message!");
 
         if (savedInstanceState == null) {
             getSupportFragmentManager().beginTransaction()

--- a/hyperion-sample/src/release/java/com/willowtreeapps/hyperion/sample/debug/CustomLog.java
+++ b/hyperion-sample/src/release/java/com/willowtreeapps/hyperion/sample/debug/CustomLog.java
@@ -1,0 +1,12 @@
+package com.willowtreeapps.hyperion.sample.debug;
+
+@SuppressWarnings("unused")
+public class CustomLog {
+
+    private CustomLog() {
+    }
+
+    public static void debug(String message) {
+    }
+
+}


### PR DESCRIPTION
Release builds of the sample app depended on the hyperion timber plugin. I added debug/release class implementations to work around the dependency requirements.