### PR TITLE
Update ignore for local keystores and module build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 *.project
 *.classpath
 *.prefs
+*.jks
+/*/build


### PR DESCRIPTION
Added two extra ignore lines to fix common issues.
- Ignore jks so it's easier to have a local dummy keystore for testing release builds
- Ignore 2nd level build directories which is helpful when switching between branches