### PR TITLE
Fix Geiger Counter plugin list item view height

### DIFF
--- a/hyperion-geiger-counter/src/main/res/layout/hgc_item_plugin.xml
+++ b/hyperion-geiger-counter/src/main/res/layout/hgc_item_plugin.xml
@@ -2,7 +2,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #111 
The view of this plugin list item was set to match_parent. So it was taking up the entire view of the plugin drawer (or whatever was left). This should fix that.

