### PR TITLE
allow developers to customize the foreground notification text

### DIFF
--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionService.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionService.java
@@ -54,14 +54,31 @@ public class HyperionService extends Service {
     }
 
     private Notification createNotification(Activity activity) {
-        return new NotificationCompat.Builder(this, CHANNEL_ID)
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, CHANNEL_ID)
                 .setContentIntent(createContentPendingIntent())
-                .setSubText(getString(R.string.hype_notification_subtext))
                 .setTicker("")
                 .setSmallIcon(R.drawable.hype_logo)
                 .setOngoing(true)
-                .setVibrate(new long[] { 0 })
-                .build();
+                .setVibrate(new long[]{0});
+
+        String contentTitle = getString(R.string.hype_notification_content_title);
+        String contentText = getString(R.string.hype_notification_content_text);
+        String subText = getString(R.string.hype_notification_subtext);
+
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
+            builder.setContentTitle(contentTitle);
+            builder.setContentText(contentText.isEmpty() ? subText : contentText);
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            builder.setContentTitle(contentTitle);
+            builder.setContentText(contentText);
+            builder.setSubText(subText);
+        } else {
+            builder.setContentTitle(contentTitle.isEmpty() ? null : contentTitle);
+            builder.setContentText(contentText.isEmpty() ? null : contentText);
+            builder.setSubText(subText);
+        }
+
+        return builder.build();
     }
 
     private PendingIntent createContentPendingIntent() {

--- a/hyperion-core/src/main/res/values/strings.xml
+++ b/hyperion-core/src/main/res/values/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <public name="hype_core" type="string">Hyperion Core</public>
     <string name="hype_plugin_load_failure">Failed to load plugins.\\n%s</string>
+    <string name="hype_notification_content_title">Hyperion</string>
+    <string name="hype_notification_content_text"></string>
     <string name="hype_notification_subtext">Tap to open the menu.</string>
     <string name="hype_notification_action_open_drawer">Open Menu</string>
     <string name="hype_notification_channel_name">Hyperion Foreground Notification</string>


### PR DESCRIPTION
Addresses #125 
This will allow customization of the Notification title and text by overriding 

- `hype_notification_content_title`
- `hype_notification_content_text`

in `strings.xml`. A page in the repos Wiki section could be used to provide more information if needed.
