### PR TITLE
Change version string to include "Hyperion"

### DIFF
--- a/hyperion-core/src/main/res/values/strings.xml
+++ b/hyperion-core/src/main/res/values/strings.xml
@@ -7,5 +7,5 @@
     <string name="hype_notification_action_open_drawer">Open Menu</string>
     <string name="hype_notification_channel_name">Hyperion Foreground Notification</string>
     <string name="hype_notification_channel_description">Channel used for displaying the Hyperion foreground notification.</string>
-    <string name="hype_version_text">v%s</string>
+    <string name="hype_version_text">Hyperion v%s</string>
 </resources>


### PR DESCRIPTION
Make it clear that this is the Hyperion version, not the version of the app which applies Hyperion. I had a QA person mistake this for our own app version today.

![device-2018-06-23-145044](https://user-images.githubusercontent.com/1980553/41812670-1690e022-76f5-11e8-9d92-e3c43193f009.png)
