### PR TITLE
Added BuildConfig name override through resources

### DIFF
--- a/hyperion-build-config/README.md
+++ b/hyperion-build-config/README.md
@@ -1,6 +1,15 @@
 # Build Config
 Plugin for viewing the BuildConfig values of the application.
 
+## Configuration
+For most applications, configuration is not necessary. In certain cases the name of the BuildConfig file will need to be manually configured. An example case is usage of the `applicationIdSuffix` modifier in the Android Gradle plugin `buildType` modifier.
+
+`strings.xml` 
+```xml
+<!-- override BuildConfig name -->
+<string name="hbc_target_build_config_name">com.example.myapp.BuildConfig</string>
+```
+
 ## Notes
 If minification is enabled for your debug builds, you will likely want to update proguard to keep your BuildConfig class.  
 

--- a/hyperion-build-config/src/main/java/com/willowtreeapps/hyperion/buildconfig/list/BuildConfigListActivity.java
+++ b/hyperion-build-config/src/main/java/com/willowtreeapps/hyperion/buildconfig/list/BuildConfigListActivity.java
@@ -44,10 +44,19 @@ public class BuildConfigListActivity extends AppCompatActivity {
         return true;
     }
 
+    private String buildConfigName() {
+        String resString = getString(R.string.hbc_target_build_config_name);
+        if (resString.isEmpty()) {
+            return getPackageName() + ".BuildConfig";
+        } else {
+            return resString;
+        }
+    }
+
     private List<BuildConfigValue> getBuildConfigValues() {
         List<BuildConfigValue> buildConfigValues = new LinkedList<>();
         try {
-            Class<?> buildConfigClass = Class.forName(getPackageName() + ".BuildConfig");
+            Class<?> buildConfigClass = Class.forName(buildConfigName());
             Log.d(TAG, "Checking BuildConfig " + buildConfigClass.getName());
             Field[] declaredFields = buildConfigClass.getDeclaredFields();
             for (Field declaredField : declaredFields) {

--- a/hyperion-build-config/src/main/res/values/strings.xml
+++ b/hyperion-build-config/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <public name="hbc_build_config" type="string">Hyperion-BuildConfig</public>
     <string name="hbc_plugin_name">BuildConfig</string>
     <string name="hbc_plugin_subtitle">View the application BuildConfig values.</string>
+    <string name="hbc_target_build_config_name" />
 </resources>


### PR DESCRIPTION
- Certain build configurations can break the `getPackageName() + ".BuildConfig"` logic