### PR TITLE
Extra documentation on core plugin

### DIFF
--- a/hyperion-core-no-op/src/main/java/com/willowtreeapps/hyperion/core/Hyperion.java
+++ b/hyperion-core-no-op/src/main/java/com/willowtreeapps/hyperion/core/Hyperion.java
@@ -3,6 +3,7 @@ package com.willowtreeapps.hyperion.core;
 import android.app.Activity;
 import android.view.View;
 
+@SuppressWarnings("unused")
 public final class Hyperion {
 
     public static View createPluginView(Activity activity) {

--- a/hyperion-core/README.md
+++ b/hyperion-core/README.md
@@ -1,0 +1,10 @@
+# Hyperion-Core
+The core Hyperion plugin. Required by all other plugins.
+
+## Customization
+To override the message that appears in the persistent notification, simply override the XML resource:
+```xml
+<string name="hype_notification_content_title">Custom title here</string>
+<string name="hype_notification_content_text">Custom message here</string>
+<string name="hype_notification_subtext">Tap to open the debug menu</string>
+```


### PR DESCRIPTION
Here there 👋 

I was thinking that it would be good to document some "advanced usage" of some of the individual plugins. Right now, usage is self explanitory for most and does not require or allow for configuration, but for the core plugin and potentially future plugins, it would probably be good to establish a way that you can read more about the plugin itself. 

This is done best by using sub-READMEs within the modules. [Retrofit](https://github.com/square/retrofit) is an example of another library that does this. Maybe eventually there could be links in the main README to these sub READMEs if they were lengthy enough or had enough additional features. 

For now, I found this to be a good start, since there are some allowed XML overrides that you would not know about for the core plugin unless you were to read over the source. I came across this when using the plugin and wondering how I could change the persistent notification to make it more clear to QA what exactly this `Hyperion` notification was all about. 

This PR is meant also to be a point of discussion. If you all think this additional documentation belongs elsewhere, I am happy to add the docs elsewhere.

As a bonus, I suppressed some lint warnings in the no-op plugin. 