### PR TITLE
Fix for SecurityException on API 28 (#141)

### DIFF
--- a/hyperion-core/src/main/AndroidManifest.xml
+++ b/hyperion-core/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.willowtreeapps.hyperion.core">
 
+    <!--Required for API 28 and above-->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <application>
         <provider
             android:authorities="${applicationId}.HyperionInitProvider"


### PR DESCRIPTION
Fix for the permission needed for Pie. Results in an immediate `SecurityException` without this. (#141)

Safe to add since this is a "normal" level permission and is granted automatically at runtime. 