### PR TITLE
Added share button to export the Timber logs

### DIFF
--- a/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/list/TimberLogListActivity.java
+++ b/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/list/TimberLogListActivity.java
@@ -2,11 +2,14 @@ package com.willowtreeapps.hyperion.timber.list;
 
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.app.ShareCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
+import android.view.View;
+import android.widget.Button;
 
 import com.willowtreeapps.hyperion.plugin.v1.HyperionIgnore;
 import com.willowtreeapps.hyperion.timber.R;
@@ -19,7 +22,8 @@ import java.util.List;
 import timber.log.Timber;
 
 @HyperionIgnore
-public class TimberLogListActivity extends AppCompatActivity {
+public class TimberLogListActivity extends AppCompatActivity implements View.OnClickListener {
+    Button mShareButton;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -30,6 +34,9 @@ public class TimberLogListActivity extends AppCompatActivity {
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
+
+        mShareButton = findViewById(R.id.button_share);
+        mShareButton.setOnClickListener(this);
 
         CircularBuffer<LogItem> logItemQueue = getLogItemQueue();
         RecyclerView recyclerView = findViewById(R.id.tmb_recycler);
@@ -54,4 +61,31 @@ public class TimberLogListActivity extends AppCompatActivity {
         throw new RuntimeException("TimberLogTree not planted in forest.");
     }
 
+    @Override
+    public void onClick(View view) {
+        int viewId = view.getId();
+        if (viewId == R.id.button_share) {
+            collectLogs();
+        }
+    }
+
+    private void collectLogs() {
+        CircularBuffer<LogItem> logItemQueue = getLogItemQueue();
+        int size = logItemQueue.size();
+        StringBuilder logs = new StringBuilder();
+        for (int i = 0; i < size; i++) {
+            LogItem logItem = logItemQueue.getItem(i);
+            logs.append(logItem.level)
+                    .append(" : [")
+                    .append(logItem.date)
+                    .append("] --> ")
+                    .append(logItem.message).append("\n");
+        }
+        ShareCompat.IntentBuilder
+                .from(this)
+                .setText(logs.toString())
+                // most general text sharing MIME type
+                .setType("text/plain")
+                .startChooser();
+    }
 }

--- a/hyperion-timber/src/main/res/layout/tmb_activity_timber_list.xml
+++ b/hyperion-timber/src/main/res/layout/tmb_activity_timber_list.xml
@@ -29,4 +29,11 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         app:layoutManager="android.support.v7.widget.LinearLayoutManager" />
 
+    <Button
+        android:text="Share"
+        android:id="@+id/button_share"
+        android:layout_width="match_parent"
+        android:layout_gravity="bottom"
+        android:layout_height="wrap_content" />
+
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
Creating a share option so that Logs can be shared without USB connector. Useful to get logs from remote QA.