### PR TITLE
Fix #155 invalid class loader

### DIFF
--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/ServiceLoaderPluginSource.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/ServiceLoaderPluginSource.java
@@ -12,7 +12,8 @@ class ServiceLoaderPluginSource implements PluginSource {
     @Override
     public Set<Plugin> getPlugins() {
         Set<Plugin> plugins = new HashSet<>();
-        ServiceLoader<Plugin> loader = ServiceLoader.load(Plugin.class);
+        ServiceLoader<Plugin> loader = ServiceLoader.load(
+                Plugin.class, getClass().getClassLoader());
         for (Plugin plugin : loader) {
             plugins.add(plugin);
         }

--- a/hyperion-sample/src/main/AndroidManifest.xml
+++ b/hyperion-sample/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-
+    android:sharedUserId="com.willowtreeapps.hyperion.sample"
     package="com.willowtreeapps.hyperion.sample">
 
     <application


### PR DESCRIPTION
- When `sharedUserId` is used in the manifest, the ServiceLoader uses the incorrect class loader instance resulting in a general failure of hyperion plugin loading.

fix #155 