### PR TITLE
Fix Timber crash

### DIFF
--- a/hyperion-sample/build.gradle
+++ b/hyperion-sample/build.gradle
@@ -23,7 +23,7 @@ android {
         debug {
             // Force a private static variable to be added to the BuildConfig
             testCoverageEnabled true
-            minifyEnabled true
+            minifyEnabled false
             useProguard false
         }
         release {

--- a/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/list/TimberLogListActivity.java
+++ b/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/list/TimberLogListActivity.java
@@ -64,6 +64,9 @@ public class TimberLogListActivity extends AppCompatActivity {
 
         CircularBuffer<LogItem> logItemQueue = getLogItemQueue();
         final TimberLogListAdapter adapter = new TimberLogListAdapter(logItemQueue);
+
+        int numberOfLogs = logItemQueue.size();
+        mToolbar.setSubtitle(getResources().getQuantityString(R.plurals.tmb_last_logs, numberOfLogs, numberOfLogs));
         mFilterEditText.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {

--- a/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/model/CircularBuffer.java
+++ b/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/model/CircularBuffer.java
@@ -10,6 +10,7 @@ public class CircularBuffer<T> {
     private final Object[] queue;
     private int head;
     private int size;
+    private int currentSize = 0;
 
     /**
      * Create the queue with a maximum size.
@@ -29,7 +30,11 @@ public class CircularBuffer<T> {
         queue[head] = item;
         head++;
         size++;
+        if (currentSize != queue.length) {
+            currentSize++;
+        }
         if (head == queue.length) head = 0;
+        printQueue();
     }
 
     /**
@@ -38,7 +43,7 @@ public class CircularBuffer<T> {
      * @return number of stored elements
      */
     public int size() {
-        return Math.min(this.size, queue.length);
+        return currentSize;
     }
 
     /**
@@ -54,4 +59,15 @@ public class CircularBuffer<T> {
         return (T) queue[target];
     }
 
+    private void printQueue() {
+        System.out.print("Current queue: ");
+        for (int i = 0; i < this.size(); i++) {
+            try {
+                System.out.print(" " + this.getItem(i) + " ");
+            } catch (Exception e ) {
+                System.out.print(" e ");
+            }
+        }
+        System.out.println();
+    }
 }

--- a/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/model/CircularBuffer.java
+++ b/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/model/CircularBuffer.java
@@ -11,7 +11,6 @@ public class CircularBuffer<T> {
     private int head = 0;
     private int nextHead = 0;
     private int currentSize = 0;
-    private int maxSize;
 
     /**
      * Create the queue with a maximum size.
@@ -20,7 +19,6 @@ public class CircularBuffer<T> {
      */
     public CircularBuffer(int size) {
         queue = new Object[size];
-        maxSize = size;
     }
 
     /**
@@ -31,11 +29,11 @@ public class CircularBuffer<T> {
     public void enqueue(T item) {
         head = nextHead;
         queue[head] = item;
-        if (currentSize != maxSize) {
+        if (currentSize != queue.length) {
             currentSize++;
         }
         nextHead++;
-        if (nextHead == maxSize) {
+        if (nextHead == queue.length) {
             nextHead = 0;
         }
     }

--- a/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/model/CircularBuffer.java
+++ b/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/model/CircularBuffer.java
@@ -8,9 +8,10 @@ package com.willowtreeapps.hyperion.timber.model;
 public class CircularBuffer<T> {
 
     private final Object[] queue;
-    private int head;
-    private int size;
+    private int head = 0;
+    private int nextHead = 0;
     private int currentSize = 0;
+    private int maxSize;
 
     /**
      * Create the queue with a maximum size.
@@ -19,6 +20,7 @@ public class CircularBuffer<T> {
      */
     public CircularBuffer(int size) {
         queue = new Object[size];
+        maxSize = size;
     }
 
     /**
@@ -27,14 +29,18 @@ public class CircularBuffer<T> {
      * @param item to be added
      */
     public void enqueue(T item) {
+        head = nextHead;
         queue[head] = item;
-        head++;
-        size++;
-        if (currentSize != queue.length) {
+        if (currentSize != maxSize) {
             currentSize++;
         }
-        if (head == queue.length) head = 0;
+        nextHead++;
+        if (nextHead == maxSize) {
+            nextHead = 0;
+        }
+
         printQueue();
+        //printQueueNormal();
     }
 
     /**
@@ -54,19 +60,29 @@ public class CircularBuffer<T> {
      */
     @SuppressWarnings("unchecked")
     public T getItem(int index) {
-        int target = head - 1 - index;
-        if (target < 0) target = size + target - head;
-        return (T) queue[target];
+        int target = index;
+        if (index >= maxSize) {
+            target = maxSize - index;
+        }
+        return (T) queue[head - target];
     }
 
     private void printQueue() {
-        System.out.print("Current queue: ");
+        System.out.print("Curren: ");
         for (int i = 0; i < this.size(); i++) {
             try {
                 System.out.print(" " + this.getItem(i) + " ");
-            } catch (Exception e ) {
+            } catch (Exception e) {
                 System.out.print(" e ");
             }
+        }
+        System.out.println();
+    }
+
+    private void printQueueNormal() {
+        System.out.print("Actual: ");
+        for (int i = 0; i < this.size(); i++) {
+            System.out.print(" " + queue[i] + " ");
         }
         System.out.println();
     }

--- a/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/model/CircularBuffer.java
+++ b/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/model/CircularBuffer.java
@@ -56,7 +56,7 @@ public class CircularBuffer<T> {
     @SuppressWarnings("unchecked")
     public T getItem(int index) {
         int target = head - index;
-        if (target < 0) target = queue.length + target - head;
+        if (target < 0) target = queue.length + target;
         return (T) queue[target];
     }
 }

--- a/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/model/CircularBuffer.java
+++ b/hyperion-timber/src/main/java/com/willowtreeapps/hyperion/timber/model/CircularBuffer.java
@@ -38,9 +38,6 @@ public class CircularBuffer<T> {
         if (nextHead == maxSize) {
             nextHead = 0;
         }
-
-        printQueue();
-        //printQueueNormal();
     }
 
     /**
@@ -60,30 +57,8 @@ public class CircularBuffer<T> {
      */
     @SuppressWarnings("unchecked")
     public T getItem(int index) {
-        int target = index;
-        if (index >= maxSize) {
-            target = maxSize - index;
-        }
-        return (T) queue[head - target];
-    }
-
-    private void printQueue() {
-        System.out.print("Curren: ");
-        for (int i = 0; i < this.size(); i++) {
-            try {
-                System.out.print(" " + this.getItem(i) + " ");
-            } catch (Exception e) {
-                System.out.print(" e ");
-            }
-        }
-        System.out.println();
-    }
-
-    private void printQueueNormal() {
-        System.out.print("Actual: ");
-        for (int i = 0; i < this.size(); i++) {
-            System.out.print(" " + queue[i] + " ");
-        }
-        System.out.println();
+        int target = head - index;
+        if (target < 0) target = queue.length + target - head;
+        return (T) queue[target];
     }
 }

--- a/hyperion-timber/src/main/res/values/strings.xml
+++ b/hyperion-timber/src/main/res/values/strings.xml
@@ -5,4 +5,9 @@
     <string name="tmb_plugin_subtitle">View Timber recorded log messages</string>
     <string name="tmb_filter">Filter</string>
     <string name="tmb_share">Share</string>
+    <string name="tmb_last_logs">Last </string>
+    <plurals name="tmb_last_logs">
+        <item quantity="one">Last %d log</item>
+        <item quantity="other">Last %d logs</item>
+    </plurals>
 </resources>

--- a/hyperion-timber/src/test/java/com/willowtreeapps/hyperion/timber/model/CircularBufferTest.java
+++ b/hyperion-timber/src/test/java/com/willowtreeapps/hyperion/timber/model/CircularBufferTest.java
@@ -38,11 +38,13 @@ public class CircularBufferTest {
     @Test
     public void overfill() {
         int maxSize = 10;
+        int upTo = 66;
         CircularBuffer<Integer> queue = new CircularBuffer<>(maxSize);
-        for (int i = 1; i <= maxSize * 4; i++) {
+        for (int i = upTo; i >= 1; i--) {
             queue.enqueue(i);
         }
-        assertEquals((Integer) (maxSize * 4), queue.getItem(0));
+        assertEquals((Integer) (1), queue.getItem(0));
+        assertEquals((Integer) (10), queue.getItem(maxSize - 1));
     }
 
 }

--- a/hyperion-timber/src/test/java/com/willowtreeapps/hyperion/timber/model/CircularBufferTest.java
+++ b/hyperion-timber/src/test/java/com/willowtreeapps/hyperion/timber/model/CircularBufferTest.java
@@ -38,9 +38,8 @@ public class CircularBufferTest {
     @Test
     public void overfill() {
         int maxSize = 10;
-        int upTo = 66;
         CircularBuffer<Integer> queue = new CircularBuffer<>(maxSize);
-        for (int i = upTo; i >= 1; i--) {
+        for (int i = 66; i >= 1; i--) {
             queue.enqueue(i);
         }
         assertEquals((Integer) (1), queue.getItem(0));

--- a/hyperion-timber/src/test/java/com/willowtreeapps/hyperion/timber/model/CircularBufferTest.java
+++ b/hyperion-timber/src/test/java/com/willowtreeapps/hyperion/timber/model/CircularBufferTest.java
@@ -35,4 +35,14 @@ public class CircularBufferTest {
         assertEquals((Integer) 1, queue.getItem(2));
     }
 
+    @Test
+    public void overfill() {
+        int maxSize = 10;
+        CircularBuffer<Integer> queue = new CircularBuffer<>(maxSize);
+        for (int i = 1; i <= maxSize * 4; i++) {
+            queue.enqueue(i);
+        }
+        assertEquals((Integer) (maxSize * 4), queue.getItem(0));
+    }
+
 }


### PR DESCRIPTION
This fixes a crash that would occur within the Timber activity if you were to scroll to the end of the list (index out of bounds). This is due to some issues within `CircularBuffer`, including problems with it reporting the wrong size to the adapter, and also reporting the wrong index to to moving `head` forward preemptively. 

I added a test `overfill` which would present the exceptions being thrown (so you can use that as verification for this issue being resolved).

I also took this opportunity to add a subtitle to the activity to tell the user that it is showing just the last `x` logs (since it is not obvious unless you know the code)

I also disabled `minify` on the sample build, since it was causing issues with debugging stack traces. I wasn't sure if it was enabled on purpose. 


![Screenshot_1560052718](https://user-images.githubusercontent.com/1459320/59154824-f9808400-8a40-11e9-9375-5ed543c42dfc.png)
