### PR TITLE
[bugfix] resolves #197: android 11 support; rename requireContext -> requireContextInternal to avoid conflict

### DIFF
--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionInitProvider.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionInitProvider.java
@@ -12,7 +12,7 @@ public class HyperionInitProvider extends EmptyContentProvider {
     @Override
     public boolean onCreate() {
         try {
-            final Context context = requireContext();
+            final Context context = requireContextInternal();
             Hyperion.setApplication(context);
             final Application application = (Application) context.getApplicationContext();
             final AppComponent component = AppComponent.Holder.getInstance(context);
@@ -25,7 +25,7 @@ public class HyperionInitProvider extends EmptyContentProvider {
     }
 
     @NonNull
-    private Context requireContext() {
+    private Context requireContextInternal() {
         final Context context = getContext();
         if (context == null) {
             throw new NullPointerException("context == null");


### PR DESCRIPTION
resolves #197 
rename requireContext -> requireContextInternal in HyperionInitProvider to avoid conflict with ContentProvider's public requireContext() that appears in api 30 (android 11)
That causes runtime crashes on android 11 devices for our application