### PR TITLE
Fix Screen Recording Crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
-project.ext.set("compileSdkVersion", 28)
-project.ext.set("buildToolsVersion", "28.0.3")
+project.ext.set("compileSdkVersion", 29)
+project.ext.set("buildToolsVersion", "29.0.3")
 project.ext.set("minSdkVersion", 15)
-project.ext.set("targetSdkVersion", 28)
+project.ext.set("targetSdkVersion", 29)
 
 project.ext.set("libraryGroup", 'com.willowtreeapps.hyperion')
 project.ext.set("libraryVersion", '0.9.30')

--- a/hyperion-core/src/main/AndroidManifest.xml
+++ b/hyperion-core/src/main/AndroidManifest.xml
@@ -6,12 +6,13 @@
 
     <application>
         <provider
-            android:authorities="${applicationId}.HyperionInitProvider"
             android:name=".internal.HyperionInitProvider"
+            android:authorities="${applicationId}.HyperionInitProvider"
             android:exported="false" />
         <service
             android:name=".internal.HyperionService"
-            android:exported="false"/>
+            android:exported="false"
+            android:foregroundServiceType="mediaProjection" />
     </application>
 
 </manifest>

--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionMenuController.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionMenuController.java
@@ -229,11 +229,11 @@ public class HyperionMenuController implements HyperionMenu, OverlayContainer {
         return true;
     }
 
-    public void onResume() {
+    public void onStart() {
         sensorManager.registerListener(shakeDetector, accelerometer, SensorManager.SENSOR_DELAY_UI);
     }
 
-    public void onPause() {
+    public void onStop() {
         sensorManager.unregisterListener(shakeDetector);
     }
 

--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionServiceLifecycleDelegate.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionServiceLifecycleDelegate.java
@@ -19,7 +19,7 @@ class HyperionServiceLifecycleDelegate extends LifecycleDelegate {
     }
 
     @Override
-    public void onActivityResumed(Activity activity) {
+    public void onActivityStarted(Activity activity) {
         foregroundActivity = activity;
         CoreComponent component = container.getComponent(activity);
         if (component == null) {
@@ -34,7 +34,7 @@ class HyperionServiceLifecycleDelegate extends LifecycleDelegate {
     }
 
     @Override
-    public void onActivityPaused(Activity activity) {
+    public void onActivityStopped(Activity activity) {
         if (foregroundActivity == activity) {
             CoreComponent component = container.getComponent(activity);
             if (component == null) {

--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionServiceLifecycleDelegate.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionServiceLifecycleDelegate.java
@@ -30,7 +30,7 @@ class HyperionServiceLifecycleDelegate extends LifecycleDelegate {
                 new Intent(activity, HyperionService.class),
                 connection,
                 Context.BIND_AUTO_CREATE);
-        component.getMenuController().onResume();
+        component.getMenuController().onStart();
     }
 
     @Override
@@ -42,7 +42,7 @@ class HyperionServiceLifecycleDelegate extends LifecycleDelegate {
             }
             final ServiceConnection connection = component.getServiceConnection();
             foregroundActivity.unbindService(connection);
-            component.getMenuController().onPause();
+            component.getMenuController().onStop();
             foregroundActivity = null;
         }
     }


### PR DESCRIPTION
- update compile sdk and tools to version 29 and change service to 'mediaProjection' type
- change lifecycle callbacks to onActivityStarted and onActivityStopped to fix backgrounding service issue
- resolves #196 