### PR TITLE
Add Leak Canary to Sample app and fix Connection memory leak

### DIFF
--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionIgnoreFilter.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionIgnoreFilter.java
@@ -76,6 +76,9 @@ class HyperionIgnoreFilter implements Application.ActivityLifecycleCallbacks {
         } else {
             HyperionIgnore ignore = activity.getClass().getAnnotation(HyperionIgnore.class);
             boolean shouldIgnore = ignore != null;
+            if (activity.getClass().getName().equals("leakcanary.internal.activity.LeakActivity")){
+                shouldIgnore = true;
+            }
             cache.put(clz, shouldIgnore);
             return shouldIgnore;
         }

--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionService.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionService.java
@@ -32,8 +32,8 @@ public class HyperionService extends Service {
     private static final int ACTION_REQUEST_CODE_OPEN_MENU = 0x100;
     private static final String ACTION_OPEN_MENU = "open-menu";
 
-    private final IBinder binder = new Binder();
-    private final BroadcastReceiver actionOpenMenuReceiver = new OpenMenuReceiver();
+    private BroadcastReceiver actionOpenMenuReceiver = new OpenMenuReceiver();
+    private IBinder binder = new Binder();
     private NotificationManager notificationManager;
     private WeakReference<Activity> activity;
 
@@ -110,7 +110,9 @@ public class HyperionService extends Service {
     @Override
     public void onDestroy() {
         super.onDestroy();
+        binder = null;
         unregisterReceiver(actionOpenMenuReceiver);
+        actionOpenMenuReceiver = null;
     }
 
     @Nullable
@@ -131,7 +133,7 @@ public class HyperionService extends Service {
         }
     }
 
-    final class Binder extends android.os.Binder {
+    final private class Binder extends android.os.Binder {
         HyperionService getService() {
             return HyperionService.this;
         }
@@ -156,6 +158,12 @@ public class HyperionService extends Service {
 
         @Override
         public void onServiceDisconnected(ComponentName name) {
+            this.service.detach(activity);
+            service = null;
+        }
+
+        void forceDisconnect(){
+            // `onServiceDisconnected` doesn't seem to be called as expected, so this method guarantees unbinding.
             this.service.detach(activity);
             service = null;
         }

--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionService.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionService.java
@@ -40,7 +40,7 @@ public class HyperionService extends Service {
     void attach(Activity activity) {
         this.activity = new WeakReference<>(activity);
         initChannels();
-        startForeground(NOTIFICATION_ID, createNotification(activity));
+        startForeground(NOTIFICATION_ID, createNotification());
     }
 
     void detach(Activity activity) {
@@ -53,7 +53,7 @@ public class HyperionService extends Service {
         }
     }
 
-    private Notification createNotification(Activity activity) {
+    private Notification createNotification() {
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this, CHANNEL_ID)
                 .setContentIntent(createContentPendingIntent())
                 .setTicker("")

--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionServiceLifecycleDelegate.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionServiceLifecycleDelegate.java
@@ -42,6 +42,9 @@ class HyperionServiceLifecycleDelegate extends LifecycleDelegate {
             }
             final ServiceConnection connection = component.getServiceConnection();
             foregroundActivity.unbindService(connection);
+            if (connection instanceof HyperionService.Connection){
+                ((HyperionService.Connection) connection).forceDisconnect();
+            }
             component.getMenuController().onStop();
             foregroundActivity = null;
         }

--- a/hyperion-sample/build.gradle
+++ b/hyperion-sample/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation "com.jakewharton.timber:timber:4.7.0"
     implementation 'androidx.room:room-runtime:2.0.0'
     annotationProcessor 'androidx.room:room-compiler:2.0.0'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.6'
     debugImplementation project(':hyperion-core')
     releaseImplementation project(':hyperion-core-no-op')
     debugImplementation project(':hyperion-attr')


### PR DESCRIPTION
This PR adds Leak Canary to the Sample App. This will highlight some of the leaks happening right now, and I've fixed a crucial one that would basically keep every instance of the app in memory. So before, let's say you open the sample app 3 times, you would have 3 instances in memory.

**Solution:**

* Added LeakCanary to the ignored classes on HyperionService. There's no reason to want the debug menu on this Activity
* It turns out that `Connection` under `HyperionService` was registering calls to `onServiceConnected`, but would never register `onServiceDisconnected`, even though `HyperionServiceLifecycleDelegate.onActivityStopped` gets called. I couldn't really figure out why the callback doesn't happen, but to fix the memory leak all it takes is to expose the code to clear the internal reference to the Activity that was causing the leak from `Connection`. 