### PR TITLE
Fixed crash in targetSdk 31

### DIFF
--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionService.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionService.java
@@ -83,8 +83,14 @@ public class HyperionService extends Service {
     }
 
     private PendingIntent createContentPendingIntent() {
+        final int pendingIntentFlags;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+            pendingIntentFlags = PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+        } else {
+            pendingIntentFlags = PendingIntent.FLAG_CANCEL_CURRENT;
+        }
         return PendingIntent.getBroadcast(this, ACTION_REQUEST_CODE_OPEN_MENU,
-                new Intent(ACTION_OPEN_MENU), PendingIntent.FLAG_CANCEL_CURRENT);
+                new Intent(ACTION_OPEN_MENU), pendingIntentFlags);
     }
 
     private void initChannels() {


### PR DESCRIPTION
## Issue
- Close #228 

## Overview
- Fixed crash when `targetSdkVersion` of app is set to `31`.

## Link 
- https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability