### PR TITLE
Build Phoenix dialog with AppCompat Theme to avoid crashes

### DIFF
--- a/hyperion-phoenix/src/main/java/com/willowtreeapps/hyperion/phoenix/PhoenixModule.java
+++ b/hyperion-phoenix/src/main/java/com/willowtreeapps/hyperion/phoenix/PhoenixModule.java
@@ -27,7 +27,7 @@ class PhoenixModule extends PluginModule {
 
 
     private void confirmRebirth(final Activity activity) {
-        new AlertDialog.Builder(activity)
+        new AlertDialog.Builder(activity, R.style.Theme_AppCompat_Light_Dialog_Alert)
                 .setTitle(R.string.hp_pheonix_options_title)
                 .setMultiChoiceItems(R.array.hp_phoenix_options,
                         loadPhoenixOptions(),


### PR DESCRIPTION
### At the begin I would like to thank you for creating Hyperion - the greatest development tools 🚀 

## Context
Some of the applications using Hyperion Plugins also use [Jetpack Compose](https://developer.android.com/jetpack/compose), but choosing [Phoenix](https://github.com/jczerski/Hyperion-Android/blob/develop/hyperion-phoenix) option from side menu causes with the crash:
```
com.willowtreeapps.hyperion.sample E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.willowtreeapps.hyperion.sample, PID: 16264
    android.content.res.Resources$NotFoundException: Resource ID #0x0
        at android.content.res.ResourcesImpl.getValue(ResourcesImpl.java:239)
        at android.content.res.MiuiResourcesImpl.getValue(MiuiResourcesImpl.java:96)
        at android.content.res.Resources.loadXmlResourceParser(Resources.java:2437)
        at android.content.res.Resources.getLayout(Resources.java:1269)
        at android.view.LayoutInflater.inflate(LayoutInflater.java:534)
        at android.view.LayoutInflater.inflate(LayoutInflater.java:479)
        at androidx.appcompat.app.AlertController$AlertParams.createListView(AlertController.java:989)
        at androidx.appcompat.app.AlertController$AlertParams.apply(AlertController.java:965)
        at androidx.appcompat.app.AlertDialog$Builder.create(AlertDialog.java:984)
        at com.willowtreeapps.hyperion.phoenix.PhoenixModule.confirmRebirth(PhoenixModule.java:47)
        at com.willowtreeapps.hyperion.phoenix.PhoenixModule.access$000(PhoenixModule.java:13)
        at com.willowtreeapps.hyperion.phoenix.PhoenixModule$1.onClick(PhoenixModule.java:22)
        at android.view.View.performClick(View.java:7507)
        at android.view.View.performClickInternal(View.java:7484)
        at android.view.View.access$3600(View.java:839)
        at android.view.View$PerformClick.run(View.java:28689)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:236)
        at android.app.ActivityThread.main(ActivityThread.java:8037)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:656)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:967)
```

## How reproduce crash
Please consider a such code from **sample-app** - `SplashActivity.java`:
```java
// public class SplashActivity extends androidx.appcompat.app.AppCompatActivity {
public class SplashActivity extends androidx.activity.ComponentActivity { // required activity for Jetpack Compose

    @Override
    protected void onCreate(@Nullable Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        setContentView(R.layout.activity_splash);
    }
}
```
with different (not AppCompat) parent app Theme **sample-app** - `styles.xml`:
```xml
<!-- <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar"> -->
    <style name="AppTheme" parent="android:Theme.Material.Light.NoActionBar"><!-- used for example with Jetpack Compose -->
```

### Thank you for accepting this PR in advance 🙏 
