### PR TITLE
Fix memory leaks

### DIFF
--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionService.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionService.java
@@ -34,7 +34,7 @@ public class HyperionService extends Service {
     private static final String ACTION_OPEN_MENU = "open-menu";
 
     private BroadcastReceiver actionOpenMenuReceiver = new OpenMenuReceiver();
-    private IBinder binder = new Binder();
+    private IBinder binder = new Binder(this);
     private NotificationManager notificationManager;
     private WeakReference<Activity> activity;
 
@@ -140,9 +140,16 @@ public class HyperionService extends Service {
         }
     }
 
-    final private class Binder extends android.os.Binder {
+    private final static class Binder extends android.os.Binder {
+
+        private final WeakReference<HyperionService> serviceRef;
+
+        private Binder(final HyperionService service) {
+            this.serviceRef = new WeakReference<>(service);
+        }
+
         HyperionService getService() {
-            return HyperionService.this;
+            return serviceRef.get();
         }
     }
 

--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionServiceLifecycleDelegate.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionServiceLifecycleDelegate.java
@@ -11,7 +11,6 @@ import javax.inject.Inject;
 class HyperionServiceLifecycleDelegate extends LifecycleDelegate {
 
     private final CoreComponentContainer container;
-    private Activity foregroundActivity;
 
     @Inject
     HyperionServiceLifecycleDelegate(CoreComponentContainer container) {
@@ -20,13 +19,12 @@ class HyperionServiceLifecycleDelegate extends LifecycleDelegate {
 
     @Override
     public void onActivityStarted(Activity activity) {
-        foregroundActivity = activity;
         CoreComponent component = container.getComponent(activity);
         if (component == null) {
             return;
         }
         final ServiceConnection connection = component.getServiceConnection();
-        foregroundActivity.bindService(
+        activity.bindService(
                 new Intent(activity, HyperionService.class),
                 connection,
                 Context.BIND_AUTO_CREATE);
@@ -35,18 +33,15 @@ class HyperionServiceLifecycleDelegate extends LifecycleDelegate {
 
     @Override
     public void onActivityStopped(Activity activity) {
-        if (foregroundActivity == activity) {
-            CoreComponent component = container.getComponent(activity);
-            if (component == null) {
-                return;
-            }
-            final ServiceConnection connection = component.getServiceConnection();
-            foregroundActivity.unbindService(connection);
-            if (connection instanceof HyperionService.Connection){
-                ((HyperionService.Connection) connection).forceDisconnect();
-            }
-            component.getMenuController().onStop();
-            foregroundActivity = null;
+        CoreComponent component = container.getComponent(activity);
+        if (component == null) {
+            return;
         }
+        final ServiceConnection connection = component.getServiceConnection();
+        activity.unbindService(connection);
+        if (connection instanceof HyperionService.Connection) {
+            ((HyperionService.Connection) connection).forceDisconnect();
+        }
+        component.getMenuController().onStop();
     }
 }

--- a/hyperion-sample/build.gradle
+++ b/hyperion-sample/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation "com.jakewharton.timber:timber:4.7.0"
     implementation 'androidx.room:room-runtime:2.0.0'
     annotationProcessor 'androidx.room:room-compiler:2.0.0'
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.6'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
     debugImplementation project(':hyperion-core')
     releaseImplementation project(':hyperion-core-no-op')
     debugImplementation project(':hyperion-attr')


### PR DESCRIPTION
Fixes #224.

This PR fixes two memory leaks.

The first leak is the leak of the destroyed activity. It's caused by [HyperionServiceLifecycleDelegate](/willowtreeapps/Hyperion-Android/blob/develop/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionServiceLifecycleDelegate.java#L38). It only unbinds the service for `foregroundActivity`, however, in the typical case of starting a second activity from the first activity and then return to the first activity, the lifecycle callbacks are called in the following order:
```
onActivityStarted(SecondActivity) -> foregroundActivity = SecondActivity
onActivityStopped(FirstActivity) -> foregroundActivity != FirstActivity
onActivityStarted(FirstActivity) -> foregroundActivity = FirstActivity
onActivityStopped(SecondActivity) -> foregroundActivity != SecondActivity
```
Thus the second activity never unbinds the service, causing the leak of the second activity.
I don't see a reason why we need to only unbind the service for the foreground activity, so I removed the check.

The second leak is the leak of `HyperionService` as described in #224. Changed the service to a weak reference in the Binder class.
