### PR TITLE
Fix CI publishing issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "develop" ]; then
               echo "$MAVEN_CENTRAL_SEC_RING" | base64 -d > $HOME/secring.gpg
               gpg --import --batch $HOME/secring.gpg
-              ./gradlew publish -PORG_GRADLE_PROJECT_mavenCentralUsername="$SONATYPE_USERNAME" -PORG_GRADLE_PROJECT_mavenCentralPassword="$SONATYPE_PASSWORD" -Psigning.keyId=0E7A8B89 -Psigning.password="$MAVEN_CENTRAL_KEY_PASSPHRASE" -Psigning.secretKeyRingFile=$HOME/secring.gpg -Porg.gradle.parallel=false -Porg.gradle.daemon=false
+              ./gradlew publish -PmavenCentralUsername="$SONATYPE_USERNAME" -PmavenCentralPassword="$SONATYPE_PASSWORD" -Psigning.keyId=0E7A8B89 -Psigning.password="$MAVEN_CENTRAL_KEY_PASSPHRASE" -Psigning.secretKeyRingFile=$HOME/secring.gpg -Porg.gradle.parallel=false -Porg.gradle.daemon=false
             fi
 
 workflows:


### PR DESCRIPTION
Fix CI issues from #244
Replace `ORG_GRADLE_PROJECT_mavenCentralUsername` and `ORG_GRADLE_PROJECT_mavenCentralPassword` usages with `mavenCentralUsername` and `mavenCentralPassword` since the former are used only as Environment Variables
Ref: https://github.com/vanniktech/gradle-maven-publish-plugin/issues/432#issuecomment-1275143023