### PR TITLE
Reenable parallel builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ org.gradle.jvmargs=-Xmx4800m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-org.gradle.parallel=false
+org.gradle.parallel=true
 # enable after fix https://github.com/gradle/gradle/issues/4848
 org.gradle.configureondemand=false
 android.useAndroidX=true


### PR DESCRIPTION
Disabled this because someone on a random stack overflow post said it helped their daemon crash issue -- reenabling now because it didn't help us