### PR TITLE
Shared preferences filtering

### DIFF
--- a/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/detail/SharedPreferencesDetailActivity.java
+++ b/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/detail/SharedPreferencesDetailActivity.java
@@ -3,10 +3,14 @@ package com.willowtreeapps.hyperion.sharedpreferences.detail;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
 
 import com.willowtreeapps.hyperion.plugin.v1.HyperionIgnore;
@@ -16,6 +20,7 @@ import com.willowtreeapps.hyperion.sharedpreferences.R;
 public class SharedPreferencesDetailActivity extends AppCompatActivity {
 
     public static final String KEY_PREFS_NAME = "prefs_name";
+    private SharedPreferencesNavigationView mHspNavigator;
 
     public static void start(@NonNull Context context, @NonNull String prefsName) {
         Intent intent = new Intent(context, SharedPreferencesDetailActivity.class);
@@ -27,6 +32,7 @@ public class SharedPreferencesDetailActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.hsp_activity_shared_preferences_detail);
+        mHspNavigator = findViewById(R.id.hsp_navigation_container);
         setSupportActionBar((Toolbar) findViewById(R.id.hsp_toolbar));
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
@@ -38,6 +44,33 @@ public class SharedPreferencesDetailActivity extends AppCompatActivity {
     @Override
     public boolean onSupportNavigateUp() {
         onBackPressed();
+        return true;
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        getMenuInflater().inflate(R.menu.hsp_filter, menu);
+
+        MenuItem searchViewItem = menu.findItem(R.id.menu_item_filter);
+        SearchView searchView = (SearchView) searchViewItem.getActionView();
+        searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(String query) {
+                if (mHspNavigator != null) {
+                    mHspNavigator.filter(query);
+                }
+                return false;
+            }
+
+            @Override
+            public boolean onQueryTextChange(String newText) {
+                if (mHspNavigator != null) {
+                    mHspNavigator.filter(newText);
+                }
+                return false;
+            }
+        });
         return true;
     }
 }

--- a/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/detail/SharedPreferencesDetailAdapter.java
+++ b/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/detail/SharedPreferencesDetailAdapter.java
@@ -17,6 +17,7 @@ import com.willowtreeapps.hyperion.sharedpreferences.detail.viewholder.StringSet
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,6 +32,8 @@ class SharedPreferencesDetailAdapter extends RecyclerView.Adapter<PreferenceView
     private static final int VIEW_TYPE_STRING_SET = 6;
 
     private final SharedPreferences sharedPreferences;
+
+    private String filterQuery;
 
     SharedPreferencesDetailAdapter(SharedPreferences sharedPreferences) {
         this.sharedPreferences = sharedPreferences;
@@ -127,7 +130,18 @@ class SharedPreferencesDetailAdapter extends RecyclerView.Adapter<PreferenceView
     }
 
     private Set<String> getKeys() {
-        return getSharedPreferencesMap().keySet();
+        Set<String> allKeys = getSharedPreferencesMap().keySet();
+        if (filterQuery != null) {
+            Set<String> filteredKeys = new HashSet<>();
+            for (String key : allKeys) {
+                if (key.toLowerCase().contains(filterQuery)) {
+                    filteredKeys.add(key);
+                }
+            }
+            return filteredKeys;
+        } else {
+            return allKeys;
+        }
     }
 
     private List<String> getKeysSorted() {
@@ -136,4 +150,9 @@ class SharedPreferencesDetailAdapter extends RecyclerView.Adapter<PreferenceView
         return sortedList;
     }
 
+
+    void filter(String query) {
+        filterQuery = query.toLowerCase();
+        notifyDataSetChanged();
+    }
 }

--- a/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/detail/SharedPreferencesDetailAdapter.java
+++ b/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/detail/SharedPreferencesDetailAdapter.java
@@ -152,7 +152,7 @@ class SharedPreferencesDetailAdapter extends RecyclerView.Adapter<PreferenceView
 
 
     void filter(String query) {
-        filterQuery = query.toLowerCase();
+        filterQuery = query == null ? "" : query.toLowerCase();
         notifyDataSetChanged();
     }
 }

--- a/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/detail/SharedPreferencesNavigationView.java
+++ b/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/detail/SharedPreferencesNavigationView.java
@@ -53,6 +53,10 @@ public class SharedPreferencesNavigationView extends FrameLayout {
         sharedPreferences.unregisterOnSharedPreferenceChangeListener(preferenceListener);
     }
 
+    void filter(String query) {
+        sharedPreferencesDetailAdapter.filter(query.toLowerCase());
+    }
+
     private class PreferenceListener implements OnSharedPreferenceChangeListener {
         @Override
         public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {

--- a/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/list/SharedPreferencesListActivity.java
+++ b/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/list/SharedPreferencesListActivity.java
@@ -1,9 +1,13 @@
 package com.willowtreeapps.hyperion.sharedpreferences.list;
 
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
+
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.SearchView;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.appcompat.widget.Toolbar;
 
@@ -19,6 +23,7 @@ import java.util.List;
 public class SharedPreferencesListActivity extends AppCompatActivity {
 
     private static final String PREFS_DIRECTORY = "shared_prefs";
+    private SharedPreferencesListAdapter mHspAdapter;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -32,12 +37,40 @@ public class SharedPreferencesListActivity extends AppCompatActivity {
 
         final List<String> preferences = getPreferences();
         final RecyclerView recyclerView = findViewById(R.id.hsp_prefs_recycler);
-        recyclerView.setAdapter(new SharedPreferencesListAdapter(preferences));
+        mHspAdapter = new SharedPreferencesListAdapter(preferences);
+        recyclerView.setAdapter(mHspAdapter);
     }
 
     @Override
     public boolean onSupportNavigateUp() {
         onBackPressed();
+        return true;
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        getMenuInflater().inflate(R.menu.hsp_filter, menu);
+
+        MenuItem searchViewItem = menu.findItem(R.id.menu_item_filter);
+        SearchView searchView = (SearchView) searchViewItem.getActionView();
+        searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(String query) {
+                if (mHspAdapter != null) {
+                    mHspAdapter.filter(query);
+                }
+                return false;
+            }
+
+            @Override
+            public boolean onQueryTextChange(String newText) {
+                if (mHspAdapter != null) {
+                    mHspAdapter.filter(newText);
+                }
+                return false;
+            }
+        });
         return true;
     }
 

--- a/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/list/SharedPreferencesListAdapter.java
+++ b/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/list/SharedPreferencesListAdapter.java
@@ -14,6 +14,8 @@ import java.util.List;
 class SharedPreferencesListAdapter extends RecyclerView.Adapter<SharedPreferencesFileViewHolder> {
 
     private final List<String> preferences;
+    private List<String> filteredPreferences;
+    private boolean isFilterApplied;
 
     SharedPreferencesListAdapter(List<String> preferences) {
         this.preferences = new ArrayList<>(preferences);
@@ -29,11 +31,28 @@ class SharedPreferencesListAdapter extends RecyclerView.Adapter<SharedPreference
 
     @Override
     public void onBindViewHolder(@NonNull SharedPreferencesFileViewHolder holder, int position) {
-        holder.bind(preferences.get(position));
+        String pref = isFilterApplied ? filteredPreferences.get(position) : preferences.get(position);
+        holder.bind(pref);
     }
 
     @Override
     public int getItemCount() {
-        return preferences.size();
+        return isFilterApplied ? filteredPreferences.size() : preferences.size();
     }
+
+    void filter(String query) {
+        String filterQuery = query.toLowerCase();
+        isFilterApplied = !"".equals(query);
+        this.filteredPreferences = new ArrayList<>();
+        if (isFilterApplied) {
+            for (String pref : preferences) {
+                if (!pref.toLowerCase().contains(filterQuery)) continue;
+                filteredPreferences.add(pref);
+            }
+        } else {
+            filteredPreferences.addAll(preferences);
+        }
+        notifyDataSetChanged();
+    }
+
 }

--- a/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/list/SharedPreferencesListAdapter.java
+++ b/hyperion-shared-preferences/src/main/java/com/willowtreeapps/hyperion/sharedpreferences/list/SharedPreferencesListAdapter.java
@@ -41,13 +41,14 @@ class SharedPreferencesListAdapter extends RecyclerView.Adapter<SharedPreference
     }
 
     void filter(String query) {
-        String filterQuery = query.toLowerCase();
-        isFilterApplied = !"".equals(query);
+        String filterQuery = query == null ? "" : query.toLowerCase();
+        isFilterApplied = !filterQuery.isEmpty();
         this.filteredPreferences = new ArrayList<>();
         if (isFilterApplied) {
             for (String pref : preferences) {
-                if (!pref.toLowerCase().contains(filterQuery)) continue;
-                filteredPreferences.add(pref);
+                if (pref.toLowerCase().contains(filterQuery)) {
+                    filteredPreferences.add(pref);
+                }
             }
         } else {
             filteredPreferences.addAll(preferences);

--- a/hyperion-shared-preferences/src/main/res/menu/hsp_filter.xml
+++ b/hyperion-shared-preferences/src/main/res/menu/hsp_filter.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_item_filter"
+        android:title="@string/hsp_filter"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:showAsAction="ifRoom|withText" />
+</menu>

--- a/hyperion-shared-preferences/src/main/res/values/strings.xml
+++ b/hyperion-shared-preferences/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="hsp_plugin_subtitle">View and edit your app\'s key-value storage.</string>
     <string name="hsp_preference_edit_text">Preference Value</string>
     <string name="hsp_preference_edit_action_apply">Apply</string>
+    <string name="hsp_filter">Filter</string>
 </resources>


### PR DESCRIPTION
Thanks for the great tool! It really helps in daily work.

The PR modifies Hyperion-Shared-Preferences plugin, adding ability to filter lists of preferences:
 - filter preferences files;
 - filter records in specific file.

To start filtering, click on 'Filter' item in options menu and type the query. Filtering in applied on each query change. To stop filtering, close the search widget.