### PR TITLE
Update android14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
-project.ext.set("compileSdkVersion", 30)
-project.ext.set("buildToolsVersion", "30.0.3")
+project.ext.set("compileSdkVersion", 34)
+project.ext.set("buildToolsVersion", "34.0.0")
 project.ext.set("minSdkVersion", 15)
-project.ext.set("targetSdkVersion", 30)
+project.ext.set("targetSdkVersion", 34)
 
 project.ext.set("libraryGroup", 'com.willowtreeapps.hyperion')
 project.ext.set("libraryVersion", '0.9.37')

--- a/hyperion-core/src/main/AndroidManifest.xml
+++ b/hyperion-core/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
 
     <!--Required for API 28 and above-->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION"/>
+    <uses-permission android:name="android.permission.CAPTURE_VIDEO_OUTPUT"
+        tools:ignore="ProtectedPermissions"/>
 
     <application>
         <service

--- a/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionService.java
+++ b/hyperion-core/src/main/java/com/willowtreeapps/hyperion/core/internal/HyperionService.java
@@ -12,6 +12,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
+import android.content.pm.ServiceInfo;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.IBinder;
@@ -41,7 +42,9 @@ public class HyperionService extends Service {
     void attach(Activity activity) {
         this.activity = new WeakReference<>(activity);
         initChannels();
-        startForeground(NOTIFICATION_ID, createNotification());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(NOTIFICATION_ID, createNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);
+        } else startForeground(NOTIFICATION_ID, createNotification());
     }
 
     void detach(Activity activity) {
@@ -111,7 +114,9 @@ public class HyperionService extends Service {
     public void onCreate() {
         super.onCreate();
         notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-        registerReceiver(actionOpenMenuReceiver, new IntentFilter(ACTION_OPEN_MENU));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(actionOpenMenuReceiver, new IntentFilter(ACTION_OPEN_MENU), RECEIVER_NOT_EXPORTED);
+        } else registerReceiver(actionOpenMenuReceiver, new IntentFilter(ACTION_OPEN_MENU));
     }
 
     @Override

--- a/hyperion-sample/build.gradle
+++ b/hyperion-sample/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion project.targetSdkVersion
         versionCode buildVersionCode()
         versionName version
-        multiDexEnabled true
+        multiDexEnabled false
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -27,7 +27,7 @@ android {
             minifyEnabled false
         }
         release {
-            minifyEnabled true
+            minifyEnabled false
         }
     }
 }

--- a/hyperion-sample/src/main/AndroidManifest.xml
+++ b/hyperion-sample/src/main/AndroidManifest.xml
@@ -1,6 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:sharedUserId="com.willowtreeapps.hyperion.sample"
     package="com.willowtreeapps.hyperion.sample">
+    <uses-permission android:name="android.permission.CAPTURE_VIDEO_OUTPUT"
+        tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION"/>
 
     <application
         android:name=".SampleApplication"
@@ -14,6 +19,7 @@
         <activity android:name=".MainActivity"/>
 
         <activity android:name=".SplashActivity"
+            android:exported="true"
             android:noHistory="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
# Issue
https://github.com/willowtreeapps/Hyperion-Android/issues/262

# Bug Reason
Crashes because the following Android 14 was not supported.
- Added ForegroundServiceType to the third argument of startForeground()
- Added Foreground Permission
https://developer.android.com/about/versions/14/behavior-changes-14?hl=ja

# This PR is not yet complete.

I am unable to build the sample app with the following error. Can someone please share their findings?
```
java.lang.SecurityException: Starting FGS with type mediaProjection callerApp=ProcessRecord{aed2e77 30112:com.willowtreeapps.hyperion.sample/u0a184} targetSDK=34 requires permissions: all of the permissions allOf=true [android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION] any of the permissions allOf=false [android.permission.CAPTURE_VIDEO_OUTPUT, android:project_media]
```
